### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,11 +15,11 @@ MCP4902	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-trigger					KEYWORD2
-openLatch				KEYWORD2
-DACA					KEYWORD2
-DACB					KEYWORD2
-analogWrite				KEYWORD2
+trigger	KEYWORD2
+openLatch	KEYWORD2
+DACA	KEYWORD2
+DACB	KEYWORD2
+analogWrite	KEYWORD2
 writeCommandRegister	KEYWORD2
 
 #######################################
@@ -30,10 +30,10 @@ writeCommandRegister	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-DAC 			LITERAL1
-BUF				LITERAL1
-GA				LITERAL1
-SDN				LITERAL1
-MCP4922		LITERAL1
-MCP4912		LITERAL1
-MCP4902		LITERAL1
+DAC	LITERAL1
+BUF	LITERAL1
+GA	LITERAL1
+SDN	LITERAL1
+MCP4922	LITERAL1
+MCP4912	LITERAL1
+MCP4902	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords